### PR TITLE
修复 just BLAS 环境变量检测

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,14 +7,14 @@
 # 手动覆盖：设置 MKLROOT 或 OPENBLAS_DIR 环境变量即可
 
 _detected_blas := ```
-    if [ -n "$MKLROOT" ]; then
+    if [ -n "${MKLROOT:-}" ]; then
         echo "blas-mkl"
     elif [ -d "/c/Program Files (x86)/Intel/oneAPI/mkl/latest" ] || \
          [ -d "/c/Program Files/Intel/oneAPI/mkl/latest" ] || \
          [ -d "/opt/intel/oneapi/mkl/latest" ] || \
          [ -d "/opt/intel/mkl" ]; then
         echo "blas-mkl"
-    elif [ -n "$OPENBLAS_DIR" ]; then
+    elif [ -n "${OPENBLAS_DIR:-}" ]; then
         echo "blas-openblas"
     elif pkg-config --exists openblas 2>/dev/null; then
         echo "blas-openblas"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 修复 `justfile` 中 `MKLROOT` / `OPENBLAS_DIR` 未设置时触发 shell 参数错误的问题。
- 保持原有 BLAS 检测优先级不变。

## Environment setup performed
- Linux 环境安装了 Graphviz、pkg-config、Python dev headers、SWIG、OpenGL/EGL/OSMesa/GLFW 运行依赖、`python-is-python3`。
- Rust 切换到 stable，并安装 `clippy`、`rustfmt`、`just`。
- 安装 `uv`，并用系统 Python 安装 `numpy`、`gymnasium`、Box2D/MuJoCo/Atari extras、`minari`、`DI-engine`。
- 从 GitHub 安装 `gym-hybrid`，用于注册 `Moving-v0` / `Sliding-v0`。

## Testing
- `rustc --version; cargo --version; just --version; uv --version; python3 ...; just blas-status`
- `just check`
- `just test-filter california_housing`
- `just test`
- `just example-xor`
- `just py-gym-basic`
- `just fmt-check`
- `just lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-443df192-fefd-43fc-a287-de2203e8321a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-443df192-fefd-43fc-a287-de2203e8321a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

